### PR TITLE
fixes repeated divergence after crash

### DIFF
--- a/src/mpc_wrapper.cpp
+++ b/src/mpc_wrapper.cpp
@@ -265,6 +265,8 @@ bool MpcWrapper<T>::solve(
 
   acado_inputs_ = kHoverInput_.replicate(1, kSamples);
 
+  prepare();
+
   return update(state);
 }
 


### PR DESCRIPTION
Crashing in simulation leads to divergence of MPC. 
When resetting the simulation and restarting the MPC, the previous state corrupts the optimization, leading to repetitive crashes and requiring to restart the MPC node. 

This change forces a clean solve from scratch, fixing above issue.